### PR TITLE
[Ubuntu] Ignore if packages cannot be authenticated

### DIFF
--- a/tasks/Ubuntu.yaml
+++ b/tasks/Ubuntu.yaml
@@ -18,6 +18,7 @@
   apt: 
     name: logstash
     update_cache: yes
+    allow_unauthenticated: yes
     state: present
   tags: 
      - install


### PR DESCRIPTION
Fixes failing installation on Ubuntu:

```shell
FAILED! => {"cache_update_time": 1479694405, "cache_updated": true, "changed": false, 
"failed": true, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o 
\"Dpkg::Options::=--force-confold\"     install 'logstash'' failed: E: There were 
unauthenticated packages and -y was used without --allow-unauthenticated\n", "stderr": "E: 
There were unauthenticated packages and -y was used without --allow-unauthenticated\n"
```