### PR TITLE
moving the path to the plugin installer/checker, cleaning up white space

### DIFF
--- a/tasks/plugins.yaml
+++ b/tasks/plugins.yaml
@@ -1,7 +1,7 @@
 ---
-- name: Install logstash plugins      
+- name: Install logstash plugins
   when: logstash_plugins is defined
-  command: "{{logstash_base_dir}}/bin/plugin install {{ item.plugin }}{% if item.version is defined and item.version != '' %}/{{ item.version }}{% endif %}"
+  command: "{{logstash_base_dir}}/bin/logstash-plugin install {{ item.plugin }}{% if item.version is defined and item.version != '' %}/{{ item.version }}{% endif %}"
   register: plugin_installed
   failed_when: "'Failed to install' in plugin_installed.stderr"
   changed_when: plugin_installed.rc == 0


### PR DESCRIPTION
This resolves an issue using the deprecated executable 'plugin' in favor of 'logstash-plugin' to manage plugins in logstash.